### PR TITLE
chore: set renovate git author

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,3 +27,4 @@ jobs:
           RENOVATE_AUTODISCOVER: true
           RENOVATE_AUTODISCOVER_FILTER: 'reside-eng/npm-dependency-stats-action'
           RENOVATE_NPM_TOKEN: ${{ secrets.NPM_READ_TOKEN }}
+          RENOVATE_GIT_AUTHOR: 'renovate[bot]'


### PR DESCRIPTION
In order for renovate-approve bot to approve PR, they have to have the `renovate[bot]` author - here that is hardset