### PR TITLE
fix: remove sourcemap (not loading)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prepare": "husky install",
     "lint": "eslint src/**/*.ts",
-    "build": "rimraf dist && ncc build src/index.ts --source-map --license licenses.txt",
+    "build": "rimraf dist && ncc build src/index.ts --license licenses.txt",
     "test": "yarn tsc && jest",
     "format": "prettier --write .",
     "format:check": "prettier --check ."


### PR DESCRIPTION
Removes source map since it is not being loaded in some cases and causing an error: https://github.com/reside-eng/audit-ui/runs/6871193331?check_suite_focus=true
![image](https://user-images.githubusercontent.com/2992224/173467835-fa5a01d5-320d-4d3a-8db9-49e2b9c5bf3f.png)
