### PR TITLE
fix: disable npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
     "url": "https://github.com/reside-eng/npm-dependency-stats-action.git"
   },
   "prettier": "@side/prettier-config",
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.6.0",
+  "private": true
 }


### PR DESCRIPTION
This PR is about disabling NPM publish since this custom actions is consumed directly from github and doesn't need to be published to NPM registry.

I still didn't get to the bottom of it but the deletion of our read/write NPM token used for library publish is related to the release of this repo. I'm expecting this issue to stop after disabling the npm publish. I can spend more time to understand why it was causing the deletion of the token afterward.

:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes

<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
