### PR TITLE
fix(security): pin third-party GitHub Actions to immutable SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -56,7 +56,7 @@ jobs:
         run: yarn build
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@5982a02995853159735cb838992248c4f0f16166 # v2.7.0
         id: semantic
         with:
           semantic_version: ^18
@@ -97,9 +97,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: technote-space/workflow-conclusion-action@v3.0.3
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
 
       - uses: reside-eng/workflow-status-notification-action@v1.4.8
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: technote-space/workflow-conclusion-action@v3.0.3
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
 
       - uses: reside-eng/workflow-status-notification-action@v1.4.8
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,6 @@
   ],
   "packageRules": [
     {
-      "description": "Pin third-party GitHub Action digests (SHA + version comment). Excludes reside-eng first-party actions/workflows which stay on floating major tags.",
-      "matchDepTypes": ["action"],
-      "matchPackageNames": ["!/^reside-eng\\//"],
-      "pinDigests": true
-    },
-    {
       "description": "Prevent upgrade of got to v12 which is ESM",
       "matchPackageNames": ["got"],
       "allowedVersions": "^11"

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,12 @@
   ],
   "packageRules": [
     {
+      "description": "Pin third-party GitHub Action digests (SHA + version comment). Excludes reside-eng first-party actions/workflows which stay on floating major tags.",
+      "matchDepTypes": ["action"],
+      "matchPackageNames": ["!/^reside-eng\\//"],
+      "pinDigests": true
+    },
+    {
       "description": "Prevent upgrade of got to v12 which is ESM",
       "matchPackageNames": ["got"],
       "allowedVersions": "^11"


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Action to an immutable commit SHA (with a version comment so Renovate can still manage updates).

Per GitHub's security guidance, pinning to a full-length commit SHA is currently the only way to use an action as an immutable release. The trailing `# vX.Y.Z` comment is what Renovate reads to bump both the SHA and the version together on new releases.

## Changes

- **Workflows** (2 files): every third-party `uses:` rewritten to `owner/repo@<sha> # vX.Y.Z`.
- **`renovate.json`**: added a `packageRules` entry enforcing `pinDigests: true` for third-party actions (`matchPackageNames: ["!/^reside-eng\\//"]`).

### Pinned SHA table

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` # v6.0.2 |
| `actions/setup-node` | v6 | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` # v6.4.0 |
| `cycjimmy/semantic-release-action` | v2 | `5982a02995853159735cb838992248c4f0f16166` # v2.7.0 |
| `technote-space/workflow-conclusion-action` | v3.0.3 | `45ce8e0eb155657ab8ccf346ade734257fd196a5` # v3.0.3 |

## Test plan

- [ ] Verify workflow passes on this PR
- [ ] Release workflow runs cleanly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)