### PR TITLE
chore(yarn): add age-gate config mirroring renovate trusted-org policy

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,16 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: 14d
+
+npmPreapprovedPackages:
+  - "@side/*"
+  - "@google/*"
+  - "google-*"
+  - "@datadog/*"
+  - "next"
+  - "react"
+  - "react-dom"
+  - "@yarnpkg/cli"
+
 yarnPath: .yarn/releases/yarn-4.15.0.cjs


### PR DESCRIPTION
## Context

Yarn 4.15.0 enables [`npmMinimalAgeGate`](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) by default at `1d`. Yesterday's batched `@side/*` releases hit this gate in core-service and broke six Renovate PRs (raised in https://top-agent.slack.com/archives/C0B5164BG5R/p1779990531387059).

## Change

Mirror Renovate's trusted-org age-gate policy (defined in [renovate-config/default.json:58-69](https://github.com/reside-eng/renovate-config/blob/main/default.json#L58-L69)) into yarn's `.yarnrc.yml`:

- `npmMinimalAgeGate: 14d` — match the `minimumReleaseAge: "14 days"` already enforced by Renovate at scheduling.
- `npmPreapprovedPackages` — preapprove trusted-org scopes (`@side/*`, `@google/*`, `google-*`, `@datadog/*`) and core framework packages (`next`, `react`, `react-dom`, `@yarnpkg/cli`) so they bypass the gate the same way they already do at Renovate scheduling.

## Pilot

Same change landed first in https://github.com/reside-eng/core-service/pull/6430.