### PR TITLE
chore(codeowners): require devops approval for .yarnrc.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 # Skip assigning dep updates (handled by Renovate)
 package.json
 yarn.lock
+
+# Require Devops approval for yarn config changes
+.yarnrc.yml @reside-eng/devops


### PR DESCRIPTION
## Change

`.yarnrc.yml` now encodes Side's trusted-org age-gate policy (`npmMinimalAgeGate: 14d` + `npmPreapprovedPackages`, mirrored from [renovate-config/default.json:58-69](https://github.com/reside-eng/renovate-config/blob/main/default.json#L58-L69); landed across the org today).

Per Eddie's request (https://top-agent.slack.com/archives/C0B5164BG5R/p1779999854258089), require `@reside-eng/devops` approval for future `.yarnrc.yml` changes, uniform with the rest of the org.

```
.yarnrc.yml @reside-eng/devops
```