### PR TITLE
ci: publish floating major version tag instead of major branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push updates to branch for major version
-        # If a new version is published, i.e. v1.2.3 then this step will update
-        # branch "v1" to this commit.
+      - name: Publish floating major version tag
+        # If a new version is published, i.e. v1.2.3 then this step force-moves
+        # the floating major tag "v1" to this commit, so consumers can pin @v1 and
+        # Renovate (github-tags datasource reads tags, not branches) can track it.
         # https://github.com/reside-eng/npm-dependency-stats-action/branches
         # The dist folder (built) is included so that action can be used directly from Github
         # ref (where exact versions can pull from npm)
@@ -88,7 +89,9 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add --force dist
           git commit -C HEAD --amend
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:refs/heads/v${{steps.semantic.outputs.new_release_major_version}}
+          MAJOR_TAG="v${{steps.semantic.outputs.new_release_major_version}}"
+          git tag -f "${MAJOR_TAG}"
+          git push -f https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git "refs/tags/${MAJOR_TAG}"
 
   notification:
     if: always()


### PR DESCRIPTION
## Why

Renovate's `github-actions` manager resolves versions through the **github-tags datasource, which reads git tags (`refs/tags/*`) only — not branches**. This repo's release workflow published the moving major alias (`vN`) as a **branch** (`refs/heads/vN`), so Renovate never saw `@vN` as a trackable version:

- Within a major it raised no PRs (the alias silently rode the branch).
- Across a major it couldn't float to a nonexistent `refs/tags/vN`, so it rewrote consumers to a **pinned full version** — e.g. [reside-eng/workflow-templates#1403](https://github.com/reside-eng/workflow-templates/pull/1403) (a sibling action) bumped `@v1 → @v2.0.0` instead of `@v2`.

`actions/checkout` works correctly because it publishes the consumable major (`v4`) as a real **tag**.

## What changed

- **`release.yml`**: force-move `refs/tags/vN` instead of pushing `refs/heads/vN`, at the same commit. (`dist/` is already gitignored and built on release here — no change needed.)

## Behavior notes

- **Consume this action via `@vN`** (e.g. `@v3`). Once a `vN` tag exists, Renovate floats it within a major and produces clean `@vN → @v(N+1)` PRs across majors.
- Full-version tags (`vX.Y.Z`) carry no `dist/` (only the major tag does), so `@vN` is the supported reference — consistent with the reside-eng floating-major convention.

## Follow-ups (not in this PR)

- One-time migration: create `refs/tags/vN` at each current major-branch tip and delete the stale `vN` branches (avoids ambiguous branch+tag refs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
